### PR TITLE
Bug 1202957 - added the first draft for Gecko numpad key hook R=?

### DIFF
--- a/dom/inputmethod/Keyboard.jsm
+++ b/dom/inputmethod/Keyboard.jsm
@@ -136,6 +136,7 @@ this.Keyboard = {
     mm.addMessageListener('Forms:ReplaceSurroundingText:Result:Error', this);
     mm.addMessageListener('Forms:SendKey:Result:OK', this);
     mm.addMessageListener('Forms:SendKey:Result:Error', this);
+    mm.addMessageListener('Forms:NumpadKeyPress', this);
     mm.addMessageListener('Forms:SequenceError', this);
     mm.addMessageListener('Forms:GetContext:Result:OK', this);
     mm.addMessageListener('Forms:SetComposition:Result:OK', this);
@@ -197,6 +198,7 @@ this.Keyboard = {
       case 'Forms:ReplaceSurroundingText:Result:OK':
       case 'Forms:SendKey:Result:OK':
       case 'Forms:SendKey:Result:Error':
+      case 'Forms:NumpadKeyPress':
       case 'Forms:SequenceError':
       case 'Forms:GetContext:Result:OK':
       case 'Forms:SetComposition:Result:OK':

--- a/dom/inputmethod/MozKeyboard.js
+++ b/dom/inputmethod/MozKeyboard.js
@@ -196,6 +196,7 @@ MozInputMethod.prototype = {
 
     cpmm.addWeakMessageListener('Keyboard:FocusChange', this);
     cpmm.addWeakMessageListener('Keyboard:SelectionChange', this);
+    cpmm.addWeakMessageListener('Keyboard:NumpadKeyPress', this);
     cpmm.addWeakMessageListener('Keyboard:GetContext:Result:OK', this);
     cpmm.addWeakMessageListener('Keyboard:LayoutsChange', this);
     cpmm.addWeakMessageListener('InputRegistry:Result:OK', this);
@@ -212,6 +213,7 @@ MozInputMethod.prototype = {
 
     cpmm.removeWeakMessageListener('Keyboard:FocusChange', this);
     cpmm.removeWeakMessageListener('Keyboard:SelectionChange', this);
+    cpmm.removeWeakMessageListener('Keyboard:NumpadKeyPress', this);
     cpmm.removeWeakMessageListener('Keyboard:GetContext:Result:OK', this);
     cpmm.removeWeakMessageListener('Keyboard:LayoutsChange', this);
     cpmm.removeWeakMessageListener('InputRegistry:Result:OK', this);
@@ -243,6 +245,9 @@ MozInputMethod.prototype = {
         if (this.inputcontext) {
           this._inputcontext.updateSelectionContext(data, false);
         }
+        break;
+      case 'Keyboard:NumpadKeyPress':
+        this.sendNumpadKey(data);
         break;
       case 'Keyboard:GetContext:Result:OK':
         this.setInputContext(data);
@@ -314,6 +319,22 @@ MozInputMethod.prototype = {
     this.__DOM_IMPL__.dispatchEvent(event);
   },
 
+  set onnumpadkeypress(handler) {
+    this.__DOM_IMPL__.setEventHandler("onnumpadkeypress", handler);
+  },
+
+  get onnumpadkeypress() {
+    return this.__DOM_IMPL__.getEventHandler("onnumpadkeypress");
+  },
+  
+  sendNumpadKey: function mozSendNumpadKey(data) {
+    let event = new this._window.CustomEvent("numpadkeypress", 
+        Cu.cloneInto({ detail: {key: data.key} }, this._window)
+    );
+    this.__DOM_IMPL__.dispatchEvent(event);
+  },
+
+  
   setActive: function mozInputMethodSetActive(isActive) {
     if (WindowMap.isActive(this._window) === isActive) {
       return;

--- a/dom/inputmethod/forms.js
+++ b/dom/inputmethod/forms.js
@@ -198,6 +198,7 @@ let FormAssistant = {
     addEventListener("beforeunload", this, true, false);
     addEventListener("input", this, true, false);
     addEventListener("keydown", this, true, false);
+    addEventListener("keypress", this, true, false);
     addEventListener("keyup", this, true, false);
     addMessageListener("Forms:Select:Choice", this);
     addMessageListener("Forms:Input:Value", this);
@@ -439,6 +440,23 @@ let FormAssistant = {
         }
 
         CompositionManager.endComposition('');
+        break;
+
+      case "keypress":
+        let element = this.focusedElement;
+        if (!element || !(isPlainTextField(element) || isContentEditable(element))){
+            // we don't want to mess with anything which does not support a text in it - let's quit before we get any side effects
+            break;
+        }
+
+        let key = String.fromCharCode(evt.charCode);
+        if (key >= '0' && key <= '9'){
+            sendAsyncMessage("Forms:NumpadKeyPress", {
+                "key": key
+            });
+            evt.stopPropagation();
+            evt.preventDefault();
+        }
         break;
 
       case "keyup":

--- a/dom/webidl/InputMethod.webidl
+++ b/dom/webidl/InputMethod.webidl
@@ -20,6 +20,8 @@ interface MozInputMethod : EventTarget {
   // void; implementation decides when to void the input context.
   attribute EventHandler oninputcontextchange;
 
+  attribute EventHandler onnumpadkeypress;
+
   // An "input context" is mapped to a text field that the app is
   // allow to mutate.  this attribute should be null when there is no
   // text field currently focused.


### PR DESCRIPTION
This is just a dirty POC of how multitap and predictive numpad entry modes can be implemented.
The already known (but incomplete) list of TODOs contains:
- Watch the type of focused item before doing the key cancellation
- discover a way to make numpad input as one of MozInput types (i.e. use existing interface
  instead of adding as a separate API)
- add a setting to turn numpad functionality on-off and set it to 'on' by default for RedSquare
- add a setting to turn on-screen keyboard (or other input methods) on-off and set it to 'off'
  by default for RedSquare
- try using SetComposition interface instead of getting input text for better compatibility
  with other input methods
- add a long-tap interface (API)
